### PR TITLE
Worker dashboard

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -78,3 +78,5 @@ chromedriver
 
 venv/
 chromedriver.exe
+
+worker_logs/

--- a/.gitignore
+++ b/.gitignore
@@ -80,3 +80,4 @@ venv/
 chromedriver.exe
 
 worker_logs/
+worker_supervisor.lock

--- a/README.md
+++ b/README.md
@@ -67,6 +67,14 @@ Run it in a separate terminal alongside your collectors:
 
 Only one instance of the watchdog needs to run regardless of how many collectors you have. It is recommended to always run the watchdog when running collectors.
 
+### Monitor workers with the dashboard
+
+The dashboard gives a live, browser-based view of what the collectors are doing. It reads the database only, so it never interferes with collection. Start it in its own terminal:
+
+        python worker_dashboard.py
+
+It automatically opens your browser to the dashboard and refreshes every 5 seconds. For each court type it shows the active workers (with how long ago each one last sent a heartbeat, highlighting any that have gone stale), the number of pending tasks, how many dates have been searched, and the total cases collected. The dashboard needs Flask, which is already listed in `requirements.txt`.
+
 ## How to generate person ids
 
 Many effective uses of this data require grouping criminal cases to defendant. Unfortunately, the state does not provide any unique identifier, so the [generate_person_ids.py](https://github.com/bschoenfeld/va-court-scraper/blob/master/generate_person_ids.py) script attempts to create one. The script takes all cases and breaks them into groups based on gender, day of birth (there are no years in the case data), and first letter of last name. For each group, every name is compared to every other name using a fuzzy string match. This process can take a while. The script is built so that it can be run in parallel, one execution for each month of the year. I recommend a beefy server - I use a t2.xlarge on AWS, which has 4 CPUs and 16 GB of memory.

--- a/README.md
+++ b/README.md
@@ -69,11 +69,15 @@ Only one instance of the watchdog needs to run regardless of how many collectors
 
 ### Monitor workers with the dashboard
 
-The dashboard gives a live, browser-based view of what the collectors are doing. It reads the database only, so it never interferes with collection. Start it in its own terminal:
+The dashboard gives a live, browser-based view of what the collectors are doing, and lets you schedule new collection tasks. Start it in its own terminal:
 
         python worker_dashboard.py
 
-It automatically opens your browser to the dashboard and refreshes every second. For each court type it shows the active workers (with how long ago each one last sent a heartbeat, highlighting any that have gone stale), the number of pending tasks, how many dates have been searched, and the total cases collected. While workers are active, case totals are shown as fast approximate estimates (prefixed with `~`); once a court's workers are idle, the exact count is computed and shown. The dashboard needs Flask, which is already listed in `requirements.txt`.
+It automatically opens your browser to the dashboard and refreshes every second. For each court type it shows the active workers (with how long ago each one last sent a heartbeat, highlighting any that have gone stale), the number of pending tasks, how many dates have been searched, and the total cases collected. While workers are active, case totals are shown as fast approximate estimates (prefixed with `~`); once a court's workers are idle, the exact count is computed and shown.
+
+The "Schedule tasks" form at the top creates collection tasks without the command line - the same as running `court_bulk_task_creator.py`. Choose a court level, case type, and a descending date range (start date on or after end date); leave FIPS blank to create a task for every court, or enter one to target a single court. Newly created tasks appear in the pending count and are picked up by any running collectors.
+
+The dashboard needs Flask, which is already listed in `requirements.txt`.
 
 ## How to generate person ids
 

--- a/README.md
+++ b/README.md
@@ -79,6 +79,16 @@ The "Schedule tasks" form at the top creates collection tasks without the comman
 
 The dashboard needs Flask, which is already listed in `requirements.txt`.
 
+### Start workers from the dashboard
+
+Each court card has a worker control showing how many collectors are running and a desired count you can raise or lower with the `+` / `-` buttons. The dashboard only writes the desired number to the database - it never spawns processes itself. A supervisor process does the spawning, so this works the same whether you run everything on one machine or across several servers.
+
+On every machine that should host collectors, run the supervisor:
+
+        python worker_supervisor.py
+
+The supervisor polls the desired count and starts or stops local `court_bulk_collector.py` processes to match (capped at 10, since the court site becomes unstable past that). On Windows each collector opens in its own console window so its logs stay visible. To scale across servers, run one supervisor per machine - the desired count is shared through the database, and the dashboard's "running" figure reflects the actual collectors that have registered.
+
 ## How to generate person ids
 
 Many effective uses of this data require grouping criminal cases to defendant. Unfortunately, the state does not provide any unique identifier, so the [generate_person_ids.py](https://github.com/bschoenfeld/va-court-scraper/blob/master/generate_person_ids.py) script attempts to create one. The script takes all cases and breaks them into groups based on gender, day of birth (there are no years in the case data), and first letter of last name. For each group, every name is compared to every other name using a fuzzy string match. This process can take a while. The script is built so that it can be run in parallel, one execution for each month of the year. I recommend a beefy server - I use a t2.xlarge on AWS, which has 4 CPUs and 16 GB of memory.

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ The dashboard gives a live, browser-based view of what the collectors are doing.
 
         python worker_dashboard.py
 
-It automatically opens your browser to the dashboard and refreshes every 5 seconds. For each court type it shows the active workers (with how long ago each one last sent a heartbeat, highlighting any that have gone stale), the number of pending tasks, how many dates have been searched, and the total cases collected. The dashboard needs Flask, which is already listed in `requirements.txt`.
+It automatically opens your browser to the dashboard and refreshes every second. For each court type it shows the active workers (with how long ago each one last sent a heartbeat, highlighting any that have gone stale), the number of pending tasks, how many dates have been searched, and the total cases collected. While workers are active, case totals are shown as fast approximate estimates (prefixed with `~`); once a court's workers are idle, the exact count is computed and shown. The dashboard needs Flask, which is already listed in `requirements.txt`.
 
 ## How to generate person ids
 

--- a/README.md
+++ b/README.md
@@ -77,6 +77,8 @@ It automatically opens your browser to the dashboard and refreshes every second.
 
 The "Schedule tasks" form at the top creates collection tasks without the command line - the same as running `court_bulk_task_creator.py`. Choose a court level, case type, and a descending date range (start date on or after end date); leave FIPS blank to create a task for every court, or enter one to target a single court. Newly created tasks appear in the pending count and are picked up by any running collectors.
 
+The "Scheduled tasks" box lists the tasks currently queued (court, FIPS, case type, and date range), paginated newest-first. It updates live, so tasks disappear from the list as collectors claim them.
+
 The dashboard needs Flask, which is already listed in `requirements.txt`.
 
 ### Start workers from the dashboard

--- a/README.md
+++ b/README.md
@@ -89,6 +89,8 @@ On every machine that should host collectors, run the supervisor:
 
 The supervisor polls the desired count and starts or stops local `court_bulk_collector.py` processes to match (capped at 10, since the court site becomes unstable past that). Collectors run without opening a window; each one's output is written to its own file under `worker_logs/`. To scale across servers, run one supervisor per machine - the desired count is shared through the database, and the dashboard's "running" figure reflects the actual collectors that have registered.
 
+The **Worker logs** button at the top opens a viewer for those `worker_logs/` files: pick a log on the left to see its tail on the right, refreshed live while open. Note that the dashboard reads the log directory on its own machine, so it shows logs for collectors running on that same host (in a multi-server setup, logs on other machines aren't visible here).
+
 ## How to generate person ids
 
 Many effective uses of this data require grouping criminal cases to defendant. Unfortunately, the state does not provide any unique identifier, so the [generate_person_ids.py](https://github.com/bschoenfeld/va-court-scraper/blob/master/generate_person_ids.py) script attempts to create one. The script takes all cases and breaks them into groups based on gender, day of birth (there are no years in the case data), and first letter of last name. For each group, every name is compared to every other name using a fuzzy string match. This process can take a while. The script is built so that it can be run in parallel, one execution for each month of the year. I recommend a beefy server - I use a t2.xlarge on AWS, which has 4 CPUs and 16 GB of memory.

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ On every machine that should host collectors, run the supervisor:
 
         python worker_supervisor.py
 
-The supervisor polls the desired count and starts or stops local `court_bulk_collector.py` processes to match (capped at 10, since the court site becomes unstable past that). On Windows each collector opens in its own console window so its logs stay visible. To scale across servers, run one supervisor per machine - the desired count is shared through the database, and the dashboard's "running" figure reflects the actual collectors that have registered.
+The supervisor polls the desired count and starts or stops local `court_bulk_collector.py` processes to match (capped at 10, since the court site becomes unstable past that). Collectors run without opening a window; each one's output is written to its own file under `worker_logs/`. To scale across servers, run one supervisor per machine - the desired count is shared through the database, and the dashboard's "running" figure reflects the actual collectors that have registered.
 
 ## How to generate person ids
 

--- a/court_bulk_collector.py
+++ b/court_bulk_collector.py
@@ -36,6 +36,62 @@ def get_db_connection():
         return PostgresDatabase(COURT_TYPE)
     return None
 
+# Identify this collector process so the dashboard can show it even when idle.
+WORKER_ID = '%s-%d' % (socket.gethostname(), os.getpid())
+_worker_state = {'status': 'idle', 'fips': None, 'case_type': None}
+_worker_state_lock = threading.Lock()
+# Set whenever the worker state changes, so the presence thread writes the new
+# status immediately instead of waiting for its next interval.
+_worker_state_changed = threading.Event()
+
+def set_worker_state(status, fips=None, case_type=None):
+    with _worker_state_lock:
+        _worker_state['status'] = status
+        _worker_state['fips'] = int(fips) if fips else None
+        _worker_state['case_type'] = case_type
+    _worker_state_changed.set()
+
+def start_worker_presence(interval=15):
+    # Periodically record this process in the workers table (upsert keyed on
+    # worker_id) so the dashboard sees it whether working or idle. Reuses one
+    # lightweight engine.
+    upsert_sql = text(
+        'INSERT INTO workers (worker_id, court_type, status, fips, case_type, last_alive) '
+        'VALUES (:wid, :ct, :status, :fips, :case_type, :now) '
+        'ON CONFLICT (worker_id) DO UPDATE SET '
+        'status = EXCLUDED.status, fips = EXCLUDED.fips, '
+        'case_type = EXCLUDED.case_type, last_alive = EXCLUDED.last_alive'
+    )
+    def beat():
+        engine = None
+        while True:
+            try:
+                if engine is None:
+                    engine = create_engine('postgresql://' + os.environ['POSTGRES_DB'])
+                with _worker_state_lock:
+                    st = dict(_worker_state)
+                with engine.begin() as conn:
+                    conn.execute(upsert_sql, {
+                        'wid': WORKER_ID,
+                        'ct': COURT_TYPE,
+                        'status': st['status'],
+                        'fips': st['fips'],
+                        'case_type': st['case_type'],
+                        'now': datetime.datetime.now(),
+                    })
+            except Exception:
+                if engine is not None:
+                    try:
+                        engine.dispose()
+                    except Exception:
+                        pass
+                    engine = None
+            # Wake early (and write again) as soon as the state changes.
+            if _worker_state_changed.wait(interval):
+                _worker_state_changed.clear()
+    t = threading.Thread(target=beat, daemon=True)
+    t.start()
+
 def get_cases_on_date(db, reader, fips, case_type, date, dateStr):
     print('Getting cases on ' + dateStr)
     sleep(1)
@@ -134,11 +190,13 @@ def run_collector(reader, last_task):
 
     task = db.get_and_delete_date_task(last_task)
     if task is None:
+        set_worker_state('idle')
         print('Nothing to do. Sleeping for 30 seconds.')
         sleep(30)
         db.disconnect()
         return
 
+    set_worker_state('working', task['fips'], task['case_type'])
     heartbeat_stop = start_heartbeat(task)
 
     try:
@@ -225,6 +283,14 @@ def get_reader():
             readers.DistrictCourtReader()
 
 def run():
+    # Make sure the schema (incl. the workers table) exists, then start
+    # reporting this process's presence so the dashboard can show it when idle.
+    try:
+        get_db_connection().disconnect()
+    except Exception:
+        pass
+    start_worker_presence()
+
     reader = None
     finished_task = None
     while True:
@@ -233,6 +299,7 @@ def run():
                 reader = get_reader()
             finished_task = run_collector(reader, finished_task)
         except Exception as err:
+            set_worker_state('idle')
             try:
                 reader.log_off()
             except:

--- a/court_bulk_collector.py
+++ b/court_bulk_collector.py
@@ -188,6 +188,11 @@ def run_collector(reader, last_task):
         raise
 
     heartbeat_stop.set()
+    # Record the task as completed before disconnecting
+    try:
+        db.add_completed_date_task(task)
+    except Exception:
+        print('Warning: failed to record completed task')
     db.disconnect()
     return task
 

--- a/court_bulk_collector.py
+++ b/court_bulk_collector.py
@@ -8,6 +8,7 @@ import time
 import traceback
 import socket
 import threading
+from sqlalchemy import create_engine, text
 
 # Prevent infinite hangs on network sockets (which blocks Ctrl-C in Windows)
 socket.setdefaulttimeout(60)
@@ -91,14 +92,37 @@ def get_cases_on_date(db, reader, fips, case_type, date, dateStr):
 
 def start_heartbeat(task, interval=30):
     stop_event = threading.Event()
+    active_table = '%s_court_active_date_tasks' % COURT_TYPE
+    update_sql = text(
+        'UPDATE %s SET last_alive = :now WHERE fips = :fips AND casetype = :ct'
+        % active_table
+    )
     def heartbeat():
-        # Use a separate DB connection so the heartbeat doesn't interfere
-        # with the main worker's session
+        # Build one lightweight engine for the whole heartbeat and reuse it.
+        # This avoids reconstructing PostgresDatabase every tick (which re-runs
+        # table-creation/migration checks) and issues only a minimal UPDATE.
+        engine = None
+        params = {
+            'fips': int(task['fips']),
+            'ct': task['case_type'],
+        }
         while not stop_event.wait(interval):
             try:
-                hb_db = get_db_connection()
-                hb_db.update_task_heartbeat(task)
-                hb_db.disconnect()
+                if engine is None:
+                    engine = create_engine('postgresql://' + os.environ['POSTGRES_DB'])
+                params['now'] = datetime.datetime.now()
+                with engine.begin() as conn:
+                    conn.execute(update_sql, params)
+            except Exception:
+                if engine is not None:
+                    try:
+                        engine.dispose()
+                    except Exception:
+                        pass
+                    engine = None
+        if engine is not None:
+            try:
+                engine.dispose()
             except Exception:
                 pass
     t = threading.Thread(target=heartbeat, daemon=True)

--- a/courtutils/databases/postgres.py
+++ b/courtutils/databases/postgres.py
@@ -68,6 +68,17 @@ class CircuitCourtCompletedDateTask(Base, CompletedDateTask):
 class DistrictCourtCompletedDateTask(Base, CompletedDateTask):
     __tablename__ = 'district_court_completed_date_tasks'
 
+# Tracks each running collector process so the dashboard can show workers even
+# when they are idle (between tasks), not just when they hold an active task.
+class Worker(Base):
+    __tablename__ = 'workers'
+    worker_id = Column(String, primary_key=True)
+    court_type = Column(String)
+    status = Column(String)       # 'working' or 'idle'
+    fips = Column(Integer)        # populated while working
+    case_type = Column(String)    # populated while working
+    last_alive = Column(DateTime)
+
 
 class DateSearch():
     id = Column(Integer, primary_key=True)
@@ -646,6 +657,9 @@ TABLES = [
     DistrictCourtActiveDateTask,
     CircuitCourtCompletedDateTask,
     DistrictCourtCompletedDateTask,
+
+    # Workers
+    Worker,
 
     # Searches
     CircuitCourtDateSearch,

--- a/courtutils/databases/postgres.py
+++ b/courtutils/databases/postgres.py
@@ -4,7 +4,7 @@ import os
 from datetime import datetime, date
 from sqlalchemy import (create_engine, Boolean, Column,
                         Date, DateTime, Integer, BigInteger,
-                        Float, String, ForeignKey, Index, and_)
+                        Float, String, ForeignKey, Index, and_, or_)
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import sessionmaker, relationship
@@ -824,9 +824,15 @@ class PostgresDatabase():
     def reset_stale_tasks(self, stale_threshold_seconds=120):
         from datetime import timedelta
         cutoff = datetime.now() - timedelta(seconds=stale_threshold_seconds)
+        # Include rows with a NULL last_alive: those are active tasks that never
+        # recorded a heartbeat (e.g. created before the column existed) and would
+        # otherwise never be reset, since NULL < cutoff is never true in SQL.
         stale_tasks = self.session \
             .query(self.active_date_task_builder) \
-            .filter(self.active_date_task_builder.last_alive < cutoff) \
+            .filter(or_(
+                self.active_date_task_builder.last_alive < cutoff,
+                self.active_date_task_builder.last_alive.is_(None)
+            )) \
             .all()
         for task in stale_tasks:
             print('Resetting stale task: fips=%s casetype=%s last_alive=%s' % (

--- a/courtutils/databases/postgres.py
+++ b/courtutils/databases/postgres.py
@@ -54,6 +54,20 @@ class CircuitCourtActiveDateTask(Base, ActiveDateTask):
 class DistrictCourtActiveDateTask(Base, ActiveDateTask):
     __tablename__ = 'district_court_active_date_tasks'
 
+class CompletedDateTask():
+    id = Column(Integer, primary_key=True)
+    fips = Column(Integer)
+    startdate = Column(Date)
+    enddate = Column(Date)
+    casetype = Column(String)
+    completed_at = Column(DateTime, default=datetime)
+
+class CircuitCourtCompletedDateTask(Base, CompletedDateTask):
+    __tablename__ = 'circuit_court_completed_date_tasks'
+
+class DistrictCourtCompletedDateTask(Base, CompletedDateTask):
+    __tablename__ = 'district_court_completed_date_tasks'
+
 
 class DateSearch():
     id = Column(Integer, primary_key=True)
@@ -630,6 +644,8 @@ TABLES = [
     DistrictCourtDateTask,
     CircuitCourtActiveDateTask,
     DistrictCourtActiveDateTask,
+    CircuitCourtCompletedDateTask,
+    DistrictCourtCompletedDateTask,
 
     # Searches
     CircuitCourtDateSearch,
@@ -702,11 +718,13 @@ class PostgresDatabase():
             self.court_builder = CircuitCourt
             self.date_task_builder = CircuitCourtDateTask
             self.active_date_task_builder = CircuitCourtActiveDateTask
+            self.completed_date_task_builder = CircuitCourtCompletedDateTask
             self.date_search_builder = CircuitCourtDateSearch
         else:
             self.court_builder = DistrictCourt
             self.date_task_builder = DistrictCourtDateTask
             self.active_date_task_builder = DistrictCourtActiveDateTask
+            self.completed_date_task_builder = DistrictCourtCompletedDateTask
             self.date_search_builder = DistrictCourtDateSearch
 
     def commit(self):
@@ -748,6 +766,32 @@ class PostgresDatabase():
                 )
             )
         self.session.commit()
+
+    def add_completed_date_task(self, task):
+        self.session.add(
+            self.completed_date_task_builder(
+                fips=int(task['fips']),
+                startdate=task['start_date'],
+                enddate=task['end_date'],
+                casetype=task['case_type'],
+                completed_at=datetime.now()
+            )
+        )
+        self.session.commit()
+
+    def get_recent_completed_date_tasks(self, limit=25):
+        rows = self.session \
+            .query(self.completed_date_task_builder) \
+            .order_by(self.completed_date_task_builder.completed_at.desc()) \
+            .limit(limit) \
+            .all()
+        return [{
+            'fips': str(r.fips).zfill(3),
+            'start_date': r.startdate,
+            'end_date': r.enddate,
+            'case_type': r.casetype,
+            'completed_at': r.completed_at
+        } for r in rows]
 
     def add_date_task(self, task, stopping_work=False):
         self.session.add(

--- a/courtutils/databases/postgres.py
+++ b/courtutils/databases/postgres.py
@@ -704,13 +704,21 @@ class PostgresDatabase():
         for table in TABLES:
             table.__table__.create(self.engine, checkfirst=True) #pylint: disable=E1101
 
-        # Add last_alive column to active task tables if it doesn't exist yet
+        # Add last_alive column to active task tables if it doesn't exist yet.
+        # Only ALTER when the column is actually missing: ALTER TABLE takes an
+        # ACCESS EXCLUSIVE lock even for "ADD COLUMN IF NOT EXISTS", so running
+        # it on every connection serializes against heartbeat updates and reads.
         from sqlalchemy import text
         with self.engine.connect() as conn:
             for table_name in ['circuit_court_active_date_tasks', 'district_court_active_date_tasks']:
-                conn.execute(
-                    text("ALTER TABLE %s ADD COLUMN IF NOT EXISTS last_alive TIMESTAMP" % table_name)
-                )
+                exists = conn.execute(text(
+                    "SELECT 1 FROM information_schema.columns "
+                    "WHERE table_name = :t AND column_name = 'last_alive'"
+                ), {'t': table_name}).scalar()
+                if not exists:
+                    conn.execute(
+                        text("ALTER TABLE %s ADD COLUMN last_alive TIMESTAMP" % table_name)
+                    )
             conn.commit()
 
         self.court_type = court_type
@@ -854,16 +862,6 @@ class PostgresDatabase():
             except IntegrityError:
                 print('WARNING - FAILED TO GET NEW TASK')
                 self.session.rollback()
-
-    def update_task_heartbeat(self, task):
-        self.session \
-            .query(self.active_date_task_builder) \
-            .filter(
-                self.active_date_task_builder.fips == int(task['fips']),
-                self.active_date_task_builder.casetype == task['case_type']
-            ) \
-            .update({'last_alive': datetime.now()}, synchronize_session=False)
-        self.session.commit()
 
     def reset_stale_tasks(self, stale_threshold_seconds=120):
         from datetime import timedelta

--- a/courtutils/databases/postgres.py
+++ b/courtutils/databases/postgres.py
@@ -79,6 +79,15 @@ class Worker(Base):
     case_type = Column(String)    # populated while working
     last_alive = Column(DateTime)
 
+# Desired number of collector processes per court type. The dashboard writes
+# this; a worker_supervisor.py on each host reads it and starts/stops local
+# collectors to match.
+class WorkerTarget(Base):
+    __tablename__ = 'worker_targets'
+    court_type = Column(String, primary_key=True)
+    desired_count = Column(Integer)
+    updated_at = Column(DateTime)
+
 
 class DateSearch():
     id = Column(Integer, primary_key=True)
@@ -660,6 +669,7 @@ TABLES = [
 
     # Workers
     Worker,
+    WorkerTarget,
 
     # Searches
     CircuitCourtDateSearch,

--- a/worker_dashboard.py
+++ b/worker_dashboard.py
@@ -42,6 +42,8 @@ ensure_schema()
 
 # The court site becomes unstable past ~10 collectors, so cap the desired count.
 MAX_WORKERS = 10
+# Directory the supervisor writes per-worker logs to (relative to repo root).
+LOG_DIR = 'worker_logs'
 
 # Case tables are created by SQLAlchemy with mixed-case names. CASE_TABLE_NAMES
 # holds the raw name (for pg_class lookups); queries that hit the table directly
@@ -334,6 +336,54 @@ def set_worker_target():
     return jsonify({'ok': True, 'court_type': court_type, 'desired_count': desired})
 
 
+def _safe_log_path(name):
+    # Only allow plain *.log filenames inside LOG_DIR (no path traversal).
+    if not name or '/' in name or '\\' in name or '..' in name or not name.endswith('.log'):
+        return None
+    path = os.path.join(LOG_DIR, name)
+    return path if os.path.isfile(path) else None
+
+
+@app.route('/api/logs')
+def list_logs():
+    items = []
+    try:
+        for n in os.listdir(LOG_DIR):
+            if not n.endswith('.log'):
+                continue
+            try:
+                st = os.stat(os.path.join(LOG_DIR, n))
+                items.append({'name': n, 'size': st.st_size, 'modified': st.st_mtime})
+            except Exception:
+                pass
+    except Exception:
+        pass
+    items.sort(key=lambda x: x['modified'], reverse=True)
+    return jsonify({'logs': items})
+
+
+@app.route('/api/logs/view')
+def view_log():
+    path = _safe_log_path(request.args.get('name', ''))
+    if not path:
+        return jsonify({'ok': False, 'error': 'Log not found'}), 404
+    try:
+        tail = max(1, min(2000, int(request.args.get('tail', 400))))
+    except (TypeError, ValueError):
+        tail = 400
+    try:
+        # Read only the tail end of the file so large logs stay cheap.
+        with open(path, 'rb') as f:
+            f.seek(0, os.SEEK_END)
+            size = f.tell()
+            f.seek(max(0, size - 256 * 1024))
+            data = f.read().decode('utf-8', 'replace')
+        content = '\n'.join(data.splitlines()[-tail:])
+    except Exception as e:
+        return jsonify({'ok': False, 'error': str(e)}), 500
+    return jsonify({'ok': True, 'name': request.args.get('name', ''), 'content': content})
+
+
 @app.route('/')
 def index():
     return PAGE
@@ -347,6 +397,22 @@ PAGE = """<!DOCTYPE html>
 <style>
   body { font-family: -apple-system, Segoe UI, Roboto, sans-serif; margin: 24px; background: #0f1115; color: #e6e6e6; }
   h1 { font-size: 20px; margin: 0 0 4px; }
+  .top { display: flex; align-items: center; justify-content: space-between; }
+  .logs-btn { background: #21262d; color: #e6e6e6; border: 1px solid #30363d; border-radius: 6px; padding: 6px 12px; cursor: pointer; font-size: 13px; }
+  .logs-btn:hover { background: #30363d; }
+  .modal { position: fixed; inset: 0; background: rgba(0,0,0,.6); display: flex; align-items: center; justify-content: center; z-index: 50; }
+  .modal-box { background: #171a21; border: 1px solid #262b36; border-radius: 8px; width: 80%; max-width: 1000px; height: 80%; display: flex; flex-direction: column; }
+  .modal-head { display: flex; align-items: center; justify-content: space-between; padding: 12px 16px; border-bottom: 1px solid #262b36; }
+  .modal-head h2 { margin: 0; font-size: 16px; }
+  .modal-head button { background: none; border: none; color: #8a8f98; font-size: 22px; cursor: pointer; line-height: 1; }
+  .modal-body { display: flex; flex: 1; min-height: 0; }
+  .log-list { width: 280px; border-right: 1px solid #262b36; overflow-y: auto; }
+  .log-item { padding: 8px 12px; cursor: pointer; border-bottom: 1px solid #1f242c; }
+  .log-item:hover { background: #1f242c; }
+  .log-item.active { background: #21262d; }
+  .log-item .ln { font-size: 12px; color: #e6e6e6; word-break: break-all; }
+  .log-item .lm { font-size: 11px; color: #8a8f98; }
+  .log-view { flex: 1; margin: 0; padding: 12px; overflow: auto; font-family: ui-monospace, Menlo, Consolas, monospace; font-size: 12px; white-space: pre-wrap; color: #cdd3dc; }
   .meta { color: #8a8f98; font-size: 13px; margin-bottom: 20px; }
   .grid { display: flex; gap: 24px; flex-wrap: wrap; }
   .court { flex: 1; min-width: 420px; background: #171a21; border: 1px solid #262b36; border-radius: 8px; padding: 16px; }
@@ -390,8 +456,23 @@ PAGE = """<!DOCTYPE html>
 </style>
 </head>
 <body>
-  <h1>Virginia Court Scraper &mdash; Worker Dashboard</h1>
+  <div class="top">
+    <h1>Virginia Court Scraper &mdash; Worker Dashboard</h1>
+    <button class="logs-btn" onclick="openLogs()">Worker logs</button>
+  </div>
   <div class="meta" id="meta">Loading&hellip;</div>
+  <div class="modal" id="logs-modal" style="display:none;">
+    <div class="modal-box">
+      <div class="modal-head">
+        <h2>Worker logs</h2>
+        <button onclick="closeLogs()">&times;</button>
+      </div>
+      <div class="modal-body">
+        <div class="log-list" id="log-list"></div>
+        <pre class="log-view" id="log-view">Select a log to view&hellip;</pre>
+      </div>
+    </div>
+  </div>
   <div class="grid" id="grid"></div>
   <div class="grid" id="grid-completed" style="margin-top:24px;">
     <div class="scheduler completed-box">
@@ -424,6 +505,48 @@ function fmtAgo(s) {
   if (s < 60) return s + 's ago';
   var m = Math.floor(s / 60);
   return m + 'm ' + (s % 60) + 's ago';
+}
+var currentLog = null;
+var logsTimer = null;
+function openLogs() {
+  document.getElementById('logs-modal').style.display = 'flex';
+  loadLogList();
+}
+function closeLogs() {
+  document.getElementById('logs-modal').style.display = 'none';
+  if (logsTimer) { clearTimeout(logsTimer); logsTimer = null; }
+  currentLog = null;
+}
+function loadLogList() {
+  fetch('/api/logs').then(function(r){ return r.json(); }).then(function(d){
+    var html = (d.logs || []).map(function(l){
+      var when = new Date(l.modified * 1000).toLocaleString();
+      var kb = (l.size / 1024).toFixed(1);
+      var active = (l.name === currentLog) ? ' active' : '';
+      return '<div class="log-item' + active + '" onclick="viewLog(&#39;' + l.name + '&#39;)">' +
+        '<div class="ln">' + l.name + '</div>' +
+        '<div class="lm">' + kb + ' KB · ' + when + '</div></div>';
+    }).join('');
+    document.getElementById('log-list').innerHTML = html || '<div class="empty">No logs yet</div>';
+  });
+}
+function viewLog(name) {
+  currentLog = name;
+  loadLogList();
+  refreshLogView();
+}
+function refreshLogView() {
+  if (!currentLog) return;
+  fetch('/api/logs/view?name=' + encodeURIComponent(currentLog) + '&tail=400')
+    .then(function(r){ return r.json(); }).then(function(d){
+      if (!d.ok) return;
+      var v = document.getElementById('log-view');
+      var atBottom = v.scrollTop + v.clientHeight >= v.scrollHeight - 20;
+      v.textContent = d.content || '(empty)';
+      if (atBottom) v.scrollTop = v.scrollHeight;
+    });
+  if (logsTimer) clearTimeout(logsTimer);
+  logsTimer = setTimeout(refreshLogView, 3000);
 }
 function setTarget(court, desired) {
   if (desired < 0) desired = 0;

--- a/worker_dashboard.py
+++ b/worker_dashboard.py
@@ -205,6 +205,7 @@ PAGE = """<!DOCTYPE html>
   .meta { color: #8a8f98; font-size: 13px; margin-bottom: 20px; }
   .grid { display: flex; gap: 24px; flex-wrap: wrap; }
   .court { flex: 1; min-width: 420px; background: #171a21; border: 1px solid #262b36; border-radius: 8px; padding: 16px; }
+  .completed-box { flex: 0 1 calc(50% - 12px); max-width: calc(50% - 12px); }
   .court h2 { font-size: 16px; margin: 0 0 12px; text-transform: capitalize; }
   .court h3.section { font-size: 12px; color: #8a8f98; text-transform: uppercase; letter-spacing: .04em; margin: 18px 0 8px; }
   .stats { display: flex; gap: 16px; margin-bottom: 14px; flex-wrap: wrap; }
@@ -246,7 +247,14 @@ function fmtWhen(iso) {
   if (!iso) return '';
   var d = new Date(iso);
   var secs = Math.floor((Date.now() - d.getTime()) / 1000);
-  return fmtAgo(secs);
+  if (secs < 60) return secs + 's ago';
+  if (secs < 3600) return Math.floor(secs / 60) + 'm ago';
+  if (secs < 86400) {
+    var h = Math.floor(secs / 3600);
+    var m = Math.floor((secs % 3600) / 60);
+    return h + 'h ' + m + 'm ago';
+  }
+  return Math.round(secs / 86400) + 'd ago';
 }
 function courtCard(name, c) {
   var rows = c.active.map(function(t) {
@@ -302,7 +310,7 @@ function renderCompleted(data) {
   var dCount = lastStatus ? lastStatus.courts.district.completed_count : 0;
   var cCount = lastStatus ? lastStatus.courts.circuit.completed_count : 0;
   document.getElementById('grid-completed').innerHTML =
-    '<div class="court">' +
+    '<div class="court completed-box">' +
     '<h2>Completed tasks</h2>' +
     '<div class="stats">' +
       '<div class="stat"><div class="n">' + data.total + '</div><div class="l">Total completed</div></div>' +

--- a/worker_dashboard.py
+++ b/worker_dashboard.py
@@ -189,6 +189,52 @@ def completed():
     })
 
 
+@app.route('/api/tasks/create', methods=['POST'])
+def create_tasks():
+    data = request.get_json(force=True, silent=True) or {}
+    court_type = (data.get('court_type') or '').strip()
+    case_type = (data.get('case_type') or '').strip()
+    start_s = (data.get('start_date') or '').strip()
+    end_s = (data.get('end_date') or '').strip()
+    fips = (data.get('fips') or '').strip()
+
+    if court_type not in ('circuit', 'district'):
+        return jsonify({'ok': False, 'error': 'Invalid court level'}), 400
+    if case_type not in ('criminal', 'civil'):
+        return jsonify({'ok': False, 'error': 'Invalid case type'}), 400
+    try:
+        start_date = datetime.strptime(start_s, '%Y-%m-%d').date()
+        end_date = datetime.strptime(end_s, '%Y-%m-%d').date()
+    except ValueError:
+        return jsonify({'ok': False, 'error': 'Invalid date (use YYYY-MM-DD)'}), 400
+    # Tasks descend from start_date down to end_date, so start must not precede end.
+    if start_date < end_date:
+        return jsonify({'ok': False, 'error': 'Start date must be on or after end date'}), 400
+    if fips:
+        try:
+            fips_list = [int(fips)]
+        except ValueError:
+            return jsonify({'ok': False, 'error': 'FIPS must be numeric'}), 400
+
+    courts_table = '%s_courts' % court_type
+    tasks_table = '%s_court_date_tasks' % court_type
+    try:
+        with engine.begin() as conn:
+            if not fips:
+                fips_list = [r[0] for r in conn.execute(text('SELECT fips FROM %s' % courts_table))]
+            if not fips_list:
+                return jsonify({'ok': False, 'error': 'No courts found - load courts first'}), 400
+            for f in fips_list:
+                conn.execute(
+                    text('INSERT INTO %s (fips, startdate, enddate, casetype) '
+                         'VALUES (:fips, :sd, :ed, :ct)' % tasks_table),
+                    {'fips': int(f), 'sd': start_date, 'ed': end_date, 'ct': case_type}
+                )
+    except Exception as e:
+        return jsonify({'ok': False, 'error': str(e)}), 500
+    return jsonify({'ok': True, 'created': len(fips_list)})
+
+
 @app.route('/')
 def index():
     return PAGE
@@ -206,6 +252,14 @@ PAGE = """<!DOCTYPE html>
   .grid { display: flex; gap: 24px; flex-wrap: wrap; }
   .court { flex: 1; min-width: 420px; background: #171a21; border: 1px solid #262b36; border-radius: 8px; padding: 16px; }
   .completed-box { flex: 0 1 calc(50% - 12px); max-width: calc(50% - 12px); }
+  .scheduler { background: #171a21; border: 1px solid #262b36; border-radius: 8px; padding: 16px; margin-bottom: 24px; }
+  .scheduler h2 { font-size: 16px; margin: 0 0 12px; }
+  .scheduler .row { display: flex; gap: 12px; align-items: flex-end; flex-wrap: wrap; }
+  .scheduler label { display: flex; flex-direction: column; font-size: 11px; color: #8a8f98; text-transform: uppercase; letter-spacing: .04em; gap: 4px; }
+  .scheduler select, .scheduler input { background: #0f1115; color: #e6e6e6; border: 1px solid #30363d; border-radius: 6px; padding: 6px 8px; font-size: 13px; }
+  .scheduler button { background: #238636; color: #fff; border: 1px solid #2ea043; border-radius: 6px; padding: 7px 16px; cursor: pointer; font-size: 13px; }
+  .scheduler button:hover { background: #2ea043; }
+  .scheduler .msg { margin-left: 8px; font-size: 13px; color: #8a8f98; }
   .court h2 { font-size: 16px; margin: 0 0 12px; text-transform: capitalize; }
   .court h3.section { font-size: 12px; color: #8a8f98; text-transform: uppercase; letter-spacing: .04em; margin: 18px 0 8px; }
   .stats { display: flex; gap: 16px; margin-bottom: 14px; flex-wrap: wrap; }
@@ -230,6 +284,28 @@ PAGE = """<!DOCTYPE html>
 <body>
   <h1>Virginia Court Scraper &mdash; Worker Dashboard</h1>
   <div class="meta" id="meta">Loading&hellip;</div>
+  <div class="scheduler">
+    <h2>Schedule tasks</h2>
+    <div class="row">
+      <label>Court level
+        <select id="sch-court"><option value="district">district</option><option value="circuit">circuit</option></select>
+      </label>
+      <label>Case type
+        <select id="sch-case"><option value="criminal">criminal</option><option value="civil">civil</option></select>
+      </label>
+      <label>Start (most recent)
+        <input type="date" id="sch-start">
+      </label>
+      <label>End (earliest)
+        <input type="date" id="sch-end">
+      </label>
+      <label>FIPS (optional)
+        <input type="text" id="sch-fips" placeholder="all courts" size="10">
+      </label>
+      <button onclick="createTasks()">Create tasks</button>
+      <span class="msg" id="sch-msg"></span>
+    </div>
+  </div>
   <div class="grid" id="grid"></div>
   <div class="grid" id="grid-completed" style="margin-top:24px;"></div>
 <script>
@@ -238,6 +314,26 @@ function fmtAgo(s) {
   if (s < 60) return s + 's ago';
   var m = Math.floor(s / 60);
   return m + 'm ' + (s % 60) + 's ago';
+}
+function createTasks() {
+  var msg = document.getElementById('sch-msg');
+  var body = {
+    court_type: document.getElementById('sch-court').value,
+    case_type: document.getElementById('sch-case').value,
+    start_date: document.getElementById('sch-start').value,
+    end_date: document.getElementById('sch-end').value,
+    fips: document.getElementById('sch-fips').value
+  };
+  if (!body.start_date || !body.end_date) { msg.textContent = 'Pick start and end dates.'; return; }
+  msg.textContent = 'Creating…';
+  fetch('/api/tasks/create', {
+    method: 'POST',
+    headers: {'Content-Type': 'application/json'},
+    body: JSON.stringify(body)
+  }).then(function(r){ return r.json(); }).then(function(d){
+    if (d.ok) { msg.textContent = 'Created ' + d.created + ' task(s).'; refresh(); }
+    else { msg.textContent = 'Error: ' + d.error; }
+  }).catch(function(e){ msg.textContent = 'Error: ' + e; });
 }
 function fmtCount(c) {
   // c is {count, approximate}; show ~ while the figure is an estimate

--- a/worker_dashboard.py
+++ b/worker_dashboard.py
@@ -520,33 +520,31 @@ PAGE = """<!DOCTYPE html>
     </div>
   </div>
   <div class="grid" id="grid"></div>
-  <div class="grid" id="grid-completed" style="margin-top:24px;">
-    <div class="scheduler completed-box">
-      <h2>Schedule tasks</h2>
-      <div class="row">
-        <label>Court level
-          <select id="sch-court"><option value="district">district</option><option value="circuit">circuit</option></select>
-        </label>
-        <label>Case type
-          <select id="sch-case"><option value="criminal">criminal</option><option value="civil">civil</option></select>
-        </label>
-        <label>Start (earliest)
-          <input type="date" id="sch-end">
-        </label>
-        <label>End (latest)
-          <input type="date" id="sch-start">
-        </label>
-        <label>FIPS (optional)
-          <input type="text" id="sch-fips" placeholder="all courts" size="10">
-        </label>
-        <button onclick="createTasks()">Create tasks</button>
-        <span class="msg" id="sch-msg"></span>
-      </div>
+  <div class="scheduler" style="margin-top:24px;">
+    <h2>Task Scheduler</h2>
+    <div class="row">
+      <label>Court level
+        <select id="sch-court"><option value="district">district</option><option value="circuit">circuit</option></select>
+      </label>
+      <label>Case type
+        <select id="sch-case"><option value="criminal">criminal</option><option value="civil">civil</option></select>
+      </label>
+      <label>Start (earliest)
+        <input type="date" id="sch-end">
+      </label>
+      <label>End (latest)
+        <input type="date" id="sch-start">
+      </label>
+      <label>FIPS (optional)
+        <input type="text" id="sch-fips" placeholder="all courts" size="10">
+      </label>
+      <button onclick="createTasks()">Create tasks</button>
+      <span class="msg" id="sch-msg"></span>
     </div>
-    <div class="court completed-box" id="completed-card"></div>
   </div>
-  <div class="grid" id="grid-pending" style="margin-top:24px;">
-    <div class="court completed-box" id="pending-card"></div>
+  <div class="grid" id="grid-completed" style="margin-top:24px;">
+    <div class="court" id="completed-card"></div>
+    <div class="court" id="pending-card"></div>
   </div>
 <script>
 function fmtAgo(s) {

--- a/worker_dashboard.py
+++ b/worker_dashboard.py
@@ -1,0 +1,319 @@
+from __future__ import absolute_import
+from __future__ import print_function
+import os
+import threading
+import webbrowser
+from datetime import datetime
+
+from flask import Flask, jsonify, request
+from sqlalchemy import create_engine, text
+
+# Seconds without a heartbeat before an active task is considered stale.
+# Matches the threshold used by task_watchdog.py.
+STALE_THRESHOLD_SECONDS = 120
+PORT = 5000
+
+app = Flask(__name__)
+engine = create_engine("postgresql://" + os.environ['POSTGRES_DB'])
+
+# Case tables are created by SQLAlchemy with mixed-case names, so they must be
+# double-quoted when queried directly.
+CASE_TABLES = {
+    'circuit': {'criminal': '"CircuitCriminalCase"', 'civil': '"CircuitCivilCase"'},
+    'district': {'criminal': '"DistrictCriminalCase"', 'civil': '"DistrictCivilCase"'},
+}
+
+
+def scalar(conn, sql):
+    """Run a COUNT-style query, returning 0 if the table doesn't exist yet."""
+    try:
+        return conn.execute(text(sql)).scalar() or 0
+    except Exception:
+        return 0
+
+
+def collect_court_status(conn, court_type):
+    active_table = '%s_court_active_date_tasks' % court_type
+    pending_table = '%s_court_date_tasks' % court_type
+    searched_table = '%s_court_dates_searched' % court_type
+
+    active = []
+    try:
+        rows = conn.execute(text(
+            'SELECT fips, casetype, startdate, enddate, last_alive '
+            'FROM %s ORDER BY last_alive DESC NULLS LAST' % active_table
+        ))
+        now = datetime.now()
+        for r in rows:
+            last_alive = r[4]
+            seconds_since = None
+            stale = True
+            if last_alive is not None:
+                seconds_since = int((now - last_alive).total_seconds())
+                stale = seconds_since > STALE_THRESHOLD_SECONDS
+            active.append({
+                'fips': str(r[0]).zfill(3),
+                'case_type': r[1],
+                'start_date': r[2].isoformat() if r[2] else None,
+                'end_date': r[3].isoformat() if r[3] else None,
+                'last_alive': last_alive.isoformat() if last_alive else None,
+                'seconds_since': seconds_since,
+                'stale': stale,
+            })
+    except Exception:
+        pass
+
+    completed_table = '%s_court_completed_date_tasks' % court_type
+    completed = []
+    try:
+        rows = conn.execute(text(
+            'SELECT fips, casetype, startdate, enddate, completed_at '
+            'FROM %s ORDER BY completed_at DESC LIMIT 10' % completed_table
+        ))
+        for r in rows:
+            completed.append({
+                'fips': str(r[0]).zfill(3),
+                'case_type': r[1],
+                'start_date': r[2].isoformat() if r[2] else None,
+                'end_date': r[3].isoformat() if r[3] else None,
+                'completed_at': r[4].isoformat() if r[4] else None,
+            })
+    except Exception:
+        pass
+
+    return {
+        'active': active,
+        'completed': completed,
+        'completed_count': scalar(conn, 'SELECT COUNT(*) FROM %s' % completed_table),
+        'pending_count': scalar(conn, 'SELECT COUNT(*) FROM %s' % pending_table),
+        'dates_searched': scalar(conn, 'SELECT COUNT(*) FROM %s' % searched_table),
+        'cases': {
+            'criminal': scalar(conn, 'SELECT COUNT(*) FROM %s' % CASE_TABLES[court_type]['criminal']),
+            'civil': scalar(conn, 'SELECT COUNT(*) FROM %s' % CASE_TABLES[court_type]['civil']),
+        },
+    }
+
+
+@app.route('/api/status')
+def status():
+    with engine.connect() as conn:
+        data = {
+            'generated_at': datetime.now().isoformat(),
+            'stale_threshold_seconds': STALE_THRESHOLD_SECONDS,
+            'courts': {
+                'district': collect_court_status(conn, 'district'),
+                'circuit': collect_court_status(conn, 'circuit'),
+            },
+        }
+    return jsonify(data)
+
+
+COMPLETED_PER_PAGE = 10
+
+
+@app.route('/api/completed')
+def completed():
+    try:
+        page = max(0, int(request.args.get('page', 0)))
+    except (TypeError, ValueError):
+        page = 0
+
+    rows = []
+    with engine.connect() as conn:
+        for court_type in ['district', 'circuit']:
+            table = '%s_court_completed_date_tasks' % court_type
+            try:
+                result = conn.execute(text(
+                    'SELECT fips, casetype, startdate, enddate, completed_at FROM %s' % table
+                ))
+                for r in result:
+                    rows.append({
+                        'court': court_type.capitalize(),
+                        'fips': str(r[0]).zfill(3),
+                        'case_type': r[1],
+                        'start_date': r[2].isoformat() if r[2] else None,
+                        'end_date': r[3].isoformat() if r[3] else None,
+                        'completed_at': r[4].isoformat() if r[4] else None,
+                        '_ts': r[4] or datetime.min,
+                    })
+            except Exception:
+                pass
+
+    rows.sort(key=lambda x: x['_ts'], reverse=True)
+    total = len(rows)
+    start = page * COMPLETED_PER_PAGE
+    page_rows = rows[start:start + COMPLETED_PER_PAGE]
+    for r in page_rows:
+        del r['_ts']
+
+    return jsonify({
+        'page': page,
+        'per_page': COMPLETED_PER_PAGE,
+        'total': total,
+        'tasks': page_rows,
+    })
+
+
+@app.route('/')
+def index():
+    return PAGE
+
+
+PAGE = """<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>VA Court Scraper - Worker Dashboard</title>
+<style>
+  body { font-family: -apple-system, Segoe UI, Roboto, sans-serif; margin: 24px; background: #0f1115; color: #e6e6e6; }
+  h1 { font-size: 20px; margin: 0 0 4px; }
+  .meta { color: #8a8f98; font-size: 13px; margin-bottom: 20px; }
+  .grid { display: flex; gap: 24px; flex-wrap: wrap; }
+  .court { flex: 1; min-width: 420px; background: #171a21; border: 1px solid #262b36; border-radius: 8px; padding: 16px; }
+  .court h2 { font-size: 16px; margin: 0 0 12px; text-transform: capitalize; }
+  .court h3.section { font-size: 12px; color: #8a8f98; text-transform: uppercase; letter-spacing: .04em; margin: 18px 0 8px; }
+  .stats { display: flex; gap: 16px; margin-bottom: 14px; flex-wrap: wrap; }
+  .stat { background: #0f1115; border-radius: 6px; padding: 8px 12px; min-width: 90px; }
+  .stat .n { font-size: 20px; font-weight: 600; }
+  .stat .l { font-size: 11px; color: #8a8f98; text-transform: uppercase; letter-spacing: .04em; }
+  table { width: 100%; border-collapse: collapse; font-size: 13px; }
+  th, td { text-align: left; padding: 6px 8px; border-bottom: 1px solid #262b36; }
+  th { color: #8a8f98; font-weight: 500; font-size: 11px; text-transform: uppercase; }
+  .ok { color: #3fb950; }
+  .stale { color: #f85149; font-weight: 600; }
+  .empty { color: #8a8f98; font-style: italic; padding: 8px; }
+  .dot { display: inline-block; width: 8px; height: 8px; border-radius: 50%; margin-right: 6px; }
+  .dot.ok { background: #3fb950; }
+  .dot.stale { background: #f85149; }
+  .pager { display: flex; align-items: center; gap: 12px; margin-top: 12px; font-size: 13px; color: #8a8f98; }
+  .pager button { background: #21262d; color: #e6e6e6; border: 1px solid #30363d; border-radius: 6px; padding: 5px 12px; cursor: pointer; }
+  .pager button:hover:not([disabled]) { background: #30363d; }
+  .pager button[disabled] { opacity: .4; cursor: default; }
+</style>
+</head>
+<body>
+  <h1>Virginia Court Scraper &mdash; Worker Dashboard</h1>
+  <div class="meta" id="meta">Loading&hellip;</div>
+  <div class="grid" id="grid"></div>
+  <div class="grid" id="grid-completed" style="margin-top:24px;"></div>
+<script>
+function fmtAgo(s) {
+  if (s === null) return 'no heartbeat';
+  if (s < 60) return s + 's ago';
+  var m = Math.floor(s / 60);
+  return m + 'm ' + (s % 60) + 's ago';
+}
+function fmtWhen(iso) {
+  if (!iso) return '';
+  var d = new Date(iso);
+  var secs = Math.floor((Date.now() - d.getTime()) / 1000);
+  return fmtAgo(secs);
+}
+function courtCard(name, c) {
+  var rows = c.active.map(function(t) {
+    var cls = t.stale ? 'stale' : 'ok';
+    return '<tr>' +
+      '<td><span class="dot ' + cls + '"></span>' + t.fips + '</td>' +
+      '<td>' + t.case_type + '</td>' +
+      '<td>' + (t.start_date || '') + ' → ' + (t.end_date || '') + '</td>' +
+      '<td class="' + cls + '">' + fmtAgo(t.seconds_since) + '</td>' +
+      '</tr>';
+  }).join('');
+  var table = c.active.length
+    ? '<table><tr><th>FIPS</th><th>Type</th><th>Date range</th><th>Last heartbeat</th></tr>' + rows + '</table>'
+    : '<div class="empty">No active workers</div>';
+
+  return '<div class="court">' +
+    '<h2>' + name + '</h2>' +
+    '<div class="stats">' +
+      '<div class="stat"><div class="n">' + c.active.length + '</div><div class="l">Active</div></div>' +
+      '<div class="stat"><div class="n">' + c.pending_count + '</div><div class="l">Pending</div></div>' +
+      '<div class="stat"><div class="n">' + c.completed_count + '</div><div class="l">Completed</div></div>' +
+      '<div class="stat"><div class="n">' + c.dates_searched + '</div><div class="l">Dates done</div></div>' +
+      '<div class="stat"><div class="n">' + c.cases.criminal + '</div><div class="l">Criminal cases</div></div>' +
+      '<div class="stat"><div class="n">' + c.cases.civil + '</div><div class="l">Civil cases</div></div>' +
+    '</div>' + table + '</div>';
+}
+var completedPage = 0;
+var lastStatus = null;
+function renderCompleted(data) {
+  var doneRows = data.tasks.map(function(t) {
+    return '<tr>' +
+      '<td>' + t.court + '</td>' +
+      '<td>' + t.fips + '</td>' +
+      '<td>' + t.case_type + '</td>' +
+      '<td>' + (t.start_date || '') + ' → ' + (t.end_date || '') + '</td>' +
+      '<td>' + fmtWhen(t.completed_at) + '</td>' +
+      '</tr>';
+  }).join('');
+  var doneTable = data.tasks.length
+    ? '<table><tr><th>Court</th><th>FIPS</th><th>Type</th><th>Date range</th><th>Completed</th></tr>' + doneRows + '</table>'
+    : '<div class="empty">No completed tasks yet</div>';
+
+  var totalPages = Math.max(1, Math.ceil(data.total / data.per_page));
+  var page = data.page;
+  var prevDisabled = page <= 0 ? 'disabled' : '';
+  var nextDisabled = (page + 1) >= totalPages ? 'disabled' : '';
+  var pager = '<div class="pager">' +
+    '<button onclick="changePage(-1)" ' + prevDisabled + '>&larr; Newer</button>' +
+    '<span>Page ' + (page + 1) + ' of ' + totalPages + '</span>' +
+    '<button onclick="changePage(1)" ' + nextDisabled + '>Older &rarr;</button>' +
+    '</div>';
+
+  var dCount = lastStatus ? lastStatus.courts.district.completed_count : 0;
+  var cCount = lastStatus ? lastStatus.courts.circuit.completed_count : 0;
+  document.getElementById('grid-completed').innerHTML =
+    '<div class="court">' +
+    '<h2>Completed tasks</h2>' +
+    '<div class="stats">' +
+      '<div class="stat"><div class="n">' + data.total + '</div><div class="l">Total completed</div></div>' +
+      '<div class="stat"><div class="n">' + dCount + '</div><div class="l">District</div></div>' +
+      '<div class="stat"><div class="n">' + cCount + '</div><div class="l">Circuit</div></div>' +
+    '</div>' + doneTable + pager + '</div>';
+}
+function loadCompleted() {
+  fetch('/api/completed?page=' + completedPage)
+    .then(function(r){ return r.json(); })
+    .then(function(data){
+      // Clamp if the last page shrank (e.g. fewer tasks than expected)
+      var totalPages = Math.max(1, Math.ceil(data.total / data.per_page));
+      if (completedPage > totalPages - 1) {
+        completedPage = totalPages - 1;
+        return loadCompleted();
+      }
+      renderCompleted(data);
+    });
+}
+function changePage(delta) {
+  completedPage = Math.max(0, completedPage + delta);
+  loadCompleted();
+}
+function refresh() {
+  fetch('/api/status').then(function(r){ return r.json(); }).then(function(d){
+    lastStatus = d;
+    document.getElementById('grid').innerHTML =
+      courtCard('District', d.courts.district) + courtCard('Circuit', d.courts.circuit);
+    loadCompleted();
+    document.getElementById('meta').textContent =
+      'Updated ' + new Date(d.generated_at).toLocaleTimeString() +
+      ' · stale after ' + d.stale_threshold_seconds + 's · auto-refresh 5s';
+  }).catch(function(e){
+    document.getElementById('meta').textContent = 'Error fetching status: ' + e;
+  });
+}
+refresh();
+setInterval(refresh, 5000);
+</script>
+</body>
+</html>"""
+
+
+def open_browser():
+    webbrowser.open('http://127.0.0.1:%d/' % PORT)
+
+
+if __name__ == '__main__':
+    # Open the browser shortly after the server starts. The reloader would
+    # otherwise trigger this twice, so it is disabled.
+    threading.Timer(1.0, open_browser).start()
+    app.run(host='127.0.0.1', port=PORT, debug=False, use_reloader=False)

--- a/worker_dashboard.py
+++ b/worker_dashboard.py
@@ -3,7 +3,7 @@ from __future__ import print_function
 import os
 import threading
 import webbrowser
-from datetime import datetime
+from datetime import datetime, timedelta
 
 from flask import Flask, jsonify, request
 from sqlalchemy import create_engine, text
@@ -11,6 +11,9 @@ from sqlalchemy import create_engine, text
 # Seconds without a heartbeat before an active task is considered stale.
 # Matches the threshold used by task_watchdog.py.
 STALE_THRESHOLD_SECONDS = 120
+# Seconds without a presence heartbeat before a worker process is treated as
+# gone and dropped from the dashboard.
+WORKER_STALE_SECONDS = 90
 PORT = 5000
 
 app = Flask(__name__)
@@ -115,9 +118,28 @@ def collect_court_status(conn, court_type):
     except Exception:
         pass
 
+    # Idle workers come from the workers table (working ones are already shown
+    # via their active task above).
+    idle = []
+    try:
+        now = datetime.now()
+        rows = conn.execute(text(
+            "SELECT worker_id, last_alive FROM workers "
+            "WHERE court_type = :ct AND status = 'idle' ORDER BY last_alive DESC"
+        ), {'ct': court_type})
+        for r in rows:
+            idle.append({
+                'worker_id': r[0],
+                'seconds_since': int((now - r[1]).total_seconds()) if r[1] else None,
+            })
+    except Exception:
+        pass
+
     has_active_workers = len(active) > 0
     return {
         'active': active,
+        'idle': idle,
+        'idle_count': len(idle),
         'completed': completed,
         'completed_count': scalar(conn, 'SELECT COUNT(*) FROM %s' % completed_table),
         'pending_count': scalar(conn, 'SELECT COUNT(*) FROM %s' % pending_table),
@@ -131,7 +153,15 @@ def collect_court_status(conn, court_type):
 
 @app.route('/api/status')
 def status():
-    with engine.connect() as conn:
+    with engine.begin() as conn:
+        # Drop workers that have stopped sending presence heartbeats.
+        try:
+            conn.execute(
+                text('DELETE FROM workers WHERE last_alive < :cutoff'),
+                {'cutoff': datetime.now() - timedelta(seconds=WORKER_STALE_SECONDS)}
+            )
+        except Exception:
+            pass
         data = {
             'generated_at': datetime.now().isoformat(),
             'stale_threshold_seconds': STALE_THRESHOLD_SECONDS,
@@ -207,9 +237,11 @@ def create_tasks():
         end_date = datetime.strptime(end_s, '%Y-%m-%d').date()
     except ValueError:
         return jsonify({'ok': False, 'error': 'Invalid date (use YYYY-MM-DD)'}), 400
-    # Tasks descend from start_date down to end_date, so start must not precede end.
+    # The form's "End (latest)" maps to start_date and "Start (earliest)" to
+    # end_date. Collectors descend from start_date down to end_date, so the
+    # most-recent date (start_date) must not precede the earliest (end_date).
     if start_date < end_date:
-        return jsonify({'ok': False, 'error': 'Start date must be on or after end date'}), 400
+        return jsonify({'ok': False, 'error': 'Start date must be on or before end date'}), 400
     if fips:
         try:
             fips_list = [int(fips)]
@@ -252,7 +284,7 @@ PAGE = """<!DOCTYPE html>
   .grid { display: flex; gap: 24px; flex-wrap: wrap; }
   .court { flex: 1; min-width: 420px; background: #171a21; border: 1px solid #262b36; border-radius: 8px; padding: 16px; }
   .completed-box { flex: 0 1 calc(50% - 12px); max-width: calc(50% - 12px); }
-  .scheduler { background: #171a21; border: 1px solid #262b36; border-radius: 8px; padding: 16px; margin-bottom: 24px; }
+  .scheduler { background: #171a21; border: 1px solid #262b36; border-radius: 8px; padding: 16px; }
   .scheduler h2 { font-size: 16px; margin: 0 0 12px; }
   .scheduler .row { display: flex; gap: 12px; align-items: flex-end; flex-wrap: wrap; }
   .scheduler label { display: flex; flex-direction: column; font-size: 11px; color: #8a8f98; text-transform: uppercase; letter-spacing: .04em; gap: 4px; }
@@ -275,6 +307,8 @@ PAGE = """<!DOCTYPE html>
   .dot { display: inline-block; width: 8px; height: 8px; border-radius: 50%; margin-right: 6px; }
   .dot.ok { background: #3fb950; }
   .dot.stale { background: #f85149; }
+  .dot.idle { background: #8a8f98; }
+  .muted { color: #8a8f98; }
   .pager { display: flex; align-items: center; gap: 12px; margin-top: 12px; font-size: 13px; color: #8a8f98; }
   .pager button { background: #21262d; color: #e6e6e6; border: 1px solid #30363d; border-radius: 6px; padding: 5px 12px; cursor: pointer; }
   .pager button:hover:not([disabled]) { background: #30363d; }
@@ -284,30 +318,32 @@ PAGE = """<!DOCTYPE html>
 <body>
   <h1>Virginia Court Scraper &mdash; Worker Dashboard</h1>
   <div class="meta" id="meta">Loading&hellip;</div>
-  <div class="scheduler">
-    <h2>Schedule tasks</h2>
-    <div class="row">
-      <label>Court level
-        <select id="sch-court"><option value="district">district</option><option value="circuit">circuit</option></select>
-      </label>
-      <label>Case type
-        <select id="sch-case"><option value="criminal">criminal</option><option value="civil">civil</option></select>
-      </label>
-      <label>Start (most recent)
-        <input type="date" id="sch-start">
-      </label>
-      <label>End (earliest)
-        <input type="date" id="sch-end">
-      </label>
-      <label>FIPS (optional)
-        <input type="text" id="sch-fips" placeholder="all courts" size="10">
-      </label>
-      <button onclick="createTasks()">Create tasks</button>
-      <span class="msg" id="sch-msg"></span>
-    </div>
-  </div>
   <div class="grid" id="grid"></div>
-  <div class="grid" id="grid-completed" style="margin-top:24px;"></div>
+  <div class="grid" id="grid-completed" style="margin-top:24px;">
+    <div class="scheduler completed-box">
+      <h2>Schedule tasks</h2>
+      <div class="row">
+        <label>Court level
+          <select id="sch-court"><option value="district">district</option><option value="circuit">circuit</option></select>
+        </label>
+        <label>Case type
+          <select id="sch-case"><option value="criminal">criminal</option><option value="civil">civil</option></select>
+        </label>
+        <label>Start (earliest)
+          <input type="date" id="sch-end">
+        </label>
+        <label>End (latest)
+          <input type="date" id="sch-start">
+        </label>
+        <label>FIPS (optional)
+          <input type="text" id="sch-fips" placeholder="all courts" size="10">
+        </label>
+        <button onclick="createTasks()">Create tasks</button>
+        <span class="msg" id="sch-msg"></span>
+      </div>
+    </div>
+    <div class="court completed-box" id="completed-card"></div>
+  </div>
 <script>
 function fmtAgo(s) {
   if (s === null) return 'no heartbeat';
@@ -356,20 +392,28 @@ function courtCard(name, c) {
   var rows = c.active.map(function(t) {
     var cls = t.stale ? 'stale' : 'ok';
     return '<tr>' +
-      '<td><span class="dot ' + cls + '"></span>' + t.fips + '</td>' +
+      '<td><span class="dot ' + cls + '"></span>working</td>' +
+      '<td>' + t.fips + '</td>' +
       '<td>' + t.case_type + '</td>' +
       '<td>' + (t.start_date || '') + ' → ' + (t.end_date || '') + '</td>' +
       '<td class="' + cls + '">' + fmtAgo(t.seconds_since) + '</td>' +
       '</tr>';
   }).join('');
-  var table = c.active.length
-    ? '<table><tr><th>FIPS</th><th>Type</th><th>Date range</th><th>Last heartbeat</th></tr>' + rows + '</table>'
-    : '<div class="empty">No active workers</div>';
+  var idleRows = (c.idle || []).map(function(w) {
+    return '<tr>' +
+      '<td><span class="dot idle"></span>idle</td>' +
+      '<td colspan="3" class="muted">' + w.worker_id + '</td>' +
+      '<td>' + fmtAgo(w.seconds_since) + '</td>' +
+      '</tr>';
+  }).join('');
+  var allRows = rows + idleRows;
+  var table = allRows
+    ? '<table><tr><th>Status</th><th>FIPS</th><th>Type</th><th>Date range</th><th>Last heartbeat</th></tr>' + allRows + '</table>'
+    : '<div class="empty">No workers</div>';
 
   return '<div class="court">' +
     '<h2>' + name + '</h2>' +
     '<div class="stats">' +
-      '<div class="stat"><div class="n">' + c.active.length + '</div><div class="l">Active</div></div>' +
       '<div class="stat"><div class="n">' + c.pending_count + '</div><div class="l">Pending</div></div>' +
       '<div class="stat"><div class="n">' + c.completed_count + '</div><div class="l">Completed</div></div>' +
       '<div class="stat"><div class="n">' + c.dates_searched + '</div><div class="l">Dates done</div></div>' +
@@ -405,14 +449,13 @@ function renderCompleted(data) {
 
   var dCount = lastStatus ? lastStatus.courts.district.completed_count : 0;
   var cCount = lastStatus ? lastStatus.courts.circuit.completed_count : 0;
-  document.getElementById('grid-completed').innerHTML =
-    '<div class="court completed-box">' +
+  document.getElementById('completed-card').innerHTML =
     '<h2>Completed tasks</h2>' +
     '<div class="stats">' +
       '<div class="stat"><div class="n">' + data.total + '</div><div class="l">Total completed</div></div>' +
       '<div class="stat"><div class="n">' + dCount + '</div><div class="l">District</div></div>' +
       '<div class="stat"><div class="n">' + cCount + '</div><div class="l">Circuit</div></div>' +
-    '</div>' + doneTable + pager + '</div>';
+    '</div>' + doneTable + pager;
 }
 function loadCompleted() {
   fetch('/api/completed?page=' + completedPage)

--- a/worker_dashboard.py
+++ b/worker_dashboard.py
@@ -16,12 +16,18 @@ PORT = 5000
 app = Flask(__name__)
 engine = create_engine("postgresql://" + os.environ['POSTGRES_DB'])
 
-# Case tables are created by SQLAlchemy with mixed-case names, so they must be
-# double-quoted when queried directly.
-CASE_TABLES = {
-    'circuit': {'criminal': '"CircuitCriminalCase"', 'civil': '"CircuitCivilCase"'},
-    'district': {'criminal': '"DistrictCriminalCase"', 'civil': '"DistrictCivilCase"'},
+# Case tables are created by SQLAlchemy with mixed-case names. CASE_TABLE_NAMES
+# holds the raw name (for pg_class lookups); queries that hit the table directly
+# must double-quote it.
+CASE_TABLE_NAMES = {
+    'circuit': {'criminal': 'CircuitCriminalCase', 'civil': 'CircuitCivilCase'},
+    'district': {'criminal': 'DistrictCriminalCase', 'civil': 'DistrictCivilCase'},
 }
+
+# Cache of exact case counts, keyed by (court_type, case_type). Only used while a
+# court has no active workers, where the count cannot change, so it stays valid
+# until workers run again.
+_exact_count_cache = {}
 
 
 def scalar(conn, sql):
@@ -30,6 +36,34 @@ def scalar(conn, sql):
         return conn.execute(text(sql)).scalar() or 0
     except Exception:
         return 0
+
+
+def case_count(conn, court_type, case_type, has_active_workers):
+    """Return the case count for a table.
+
+    While workers are active, use PostgreSQL's instant approximate row estimate
+    (pg_class.reltuples) so the 1s refresh never scans the table. Once the court
+    is idle, compute the exact COUNT(*) once and cache it (the count can't change
+    with no workers running) so we still don't rescan every second.
+    """
+    table = CASE_TABLE_NAMES[court_type][case_type]
+    key = (court_type, case_type)
+
+    if has_active_workers:
+        _exact_count_cache.pop(key, None)
+        try:
+            val = conn.execute(
+                text('SELECT reltuples::bigint FROM pg_class WHERE relname = :n'),
+                {'n': table}
+            ).scalar()
+            val = int(val) if val and val > 0 else 0
+        except Exception:
+            val = 0
+        return {'count': val, 'approximate': True}
+
+    if key not in _exact_count_cache:
+        _exact_count_cache[key] = scalar(conn, 'SELECT COUNT(*) FROM "%s"' % table)
+    return {'count': _exact_count_cache[key], 'approximate': False}
 
 
 def collect_court_status(conn, court_type):
@@ -81,6 +115,7 @@ def collect_court_status(conn, court_type):
     except Exception:
         pass
 
+    has_active_workers = len(active) > 0
     return {
         'active': active,
         'completed': completed,
@@ -88,8 +123,8 @@ def collect_court_status(conn, court_type):
         'pending_count': scalar(conn, 'SELECT COUNT(*) FROM %s' % pending_table),
         'dates_searched': scalar(conn, 'SELECT COUNT(*) FROM %s' % searched_table),
         'cases': {
-            'criminal': scalar(conn, 'SELECT COUNT(*) FROM %s' % CASE_TABLES[court_type]['criminal']),
-            'civil': scalar(conn, 'SELECT COUNT(*) FROM %s' % CASE_TABLES[court_type]['civil']),
+            'criminal': case_count(conn, court_type, 'criminal', has_active_workers),
+            'civil': case_count(conn, court_type, 'civil', has_active_workers),
         },
     }
 
@@ -203,6 +238,10 @@ function fmtAgo(s) {
   var m = Math.floor(s / 60);
   return m + 'm ' + (s % 60) + 's ago';
 }
+function fmtCount(c) {
+  // c is {count, approximate}; show ~ while the figure is an estimate
+  return (c.approximate ? '~' : '') + c.count.toLocaleString();
+}
 function fmtWhen(iso) {
   if (!iso) return '';
   var d = new Date(iso);
@@ -230,8 +269,8 @@ function courtCard(name, c) {
       '<div class="stat"><div class="n">' + c.pending_count + '</div><div class="l">Pending</div></div>' +
       '<div class="stat"><div class="n">' + c.completed_count + '</div><div class="l">Completed</div></div>' +
       '<div class="stat"><div class="n">' + c.dates_searched + '</div><div class="l">Dates done</div></div>' +
-      '<div class="stat"><div class="n">' + c.cases.criminal + '</div><div class="l">Criminal cases</div></div>' +
-      '<div class="stat"><div class="n">' + c.cases.civil + '</div><div class="l">Civil cases</div></div>' +
+      '<div class="stat"><div class="n">' + fmtCount(c.cases.criminal) + '</div><div class="l">Criminal cases</div></div>' +
+      '<div class="stat"><div class="n">' + fmtCount(c.cases.civil) + '</div><div class="l">Civil cases</div></div>' +
     '</div>' + table + '</div>';
 }
 var completedPage = 0;
@@ -288,21 +327,29 @@ function changePage(delta) {
   completedPage = Math.max(0, completedPage + delta);
   loadCompleted();
 }
+var ACTIVE_INTERVAL = 1000;
+var IDLE_INTERVAL = 10000;
+function scheduleNext(ms) { setTimeout(refresh, ms); }
 function refresh() {
   fetch('/api/status').then(function(r){ return r.json(); }).then(function(d){
     lastStatus = d;
     document.getElementById('grid').innerHTML =
       courtCard('District', d.courts.district) + courtCard('Circuit', d.courts.circuit);
     loadCompleted();
+    // Poll fast while any worker is active, slowly when everything is idle
+    var anyActive = d.courts.district.active.length + d.courts.circuit.active.length > 0;
+    var interval = anyActive ? ACTIVE_INTERVAL : IDLE_INTERVAL;
     document.getElementById('meta').textContent =
       'Updated ' + new Date(d.generated_at).toLocaleTimeString() +
-      ' · stale after ' + d.stale_threshold_seconds + 's · auto-refresh 5s';
+      ' · stale after ' + d.stale_threshold_seconds + 's · auto-refresh ' +
+      (interval / 1000) + 's · ~ = estimate';
+    scheduleNext(interval);
   }).catch(function(e){
     document.getElementById('meta').textContent = 'Error fetching status: ' + e;
+    scheduleNext(IDLE_INTERVAL);
   });
 }
 refresh();
-setInterval(refresh, 5000);
 </script>
 </body>
 </html>"""

--- a/worker_dashboard.py
+++ b/worker_dashboard.py
@@ -264,6 +264,52 @@ def completed():
     })
 
 
+PENDING_PER_PAGE = 10
+
+
+@app.route('/api/pending')
+def pending():
+    try:
+        page = max(0, int(request.args.get('page', 0)))
+    except (TypeError, ValueError):
+        page = 0
+
+    rows = []
+    with engine.connect() as conn:
+        for court_type in ['district', 'circuit']:
+            table = '%s_court_date_tasks' % court_type
+            try:
+                result = conn.execute(text(
+                    'SELECT id, fips, casetype, startdate, enddate FROM %s' % table
+                ))
+                for r in result:
+                    rows.append({
+                        'court': court_type.capitalize(),
+                        'fips': str(r[1]).zfill(3),
+                        'case_type': r[2],
+                        'start_date': r[3].isoformat() if r[3] else None,
+                        'end_date': r[4].isoformat() if r[4] else None,
+                        '_id': r[0],
+                    })
+            except Exception:
+                pass
+
+    # No created-at column on tasks, so order by id (creation order), newest first.
+    rows.sort(key=lambda x: x['_id'], reverse=True)
+    total = len(rows)
+    start = page * PENDING_PER_PAGE
+    page_rows = rows[start:start + PENDING_PER_PAGE]
+    for r in page_rows:
+        del r['_id']
+
+    return jsonify({
+        'page': page,
+        'per_page': PENDING_PER_PAGE,
+        'total': total,
+        'tasks': page_rows,
+    })
+
+
 @app.route('/api/tasks/create', methods=['POST'])
 def create_tasks():
     data = request.get_json(force=True, silent=True) or {}
@@ -499,6 +545,9 @@ PAGE = """<!DOCTYPE html>
     </div>
     <div class="court completed-box" id="completed-card"></div>
   </div>
+  <div class="grid" id="grid-pending" style="margin-top:24px;">
+    <div class="court completed-box" id="pending-card"></div>
+  </div>
 <script>
 function fmtAgo(s) {
   if (s === null) return 'no heartbeat';
@@ -688,6 +737,54 @@ function changePage(delta) {
   completedPage = Math.max(0, completedPage + delta);
   loadCompleted();
 }
+var pendingPage = 0;
+function renderPending(data) {
+  var rows = data.tasks.map(function(t) {
+    return '<tr>' +
+      '<td>' + t.court + '</td>' +
+      '<td>' + t.fips + '</td>' +
+      '<td>' + t.case_type + '</td>' +
+      '<td>' + (t.start_date || '') + ' → ' + (t.end_date || '') + '</td>' +
+      '</tr>';
+  }).join('');
+  var tbl = data.tasks.length
+    ? '<table><tr><th>Court</th><th>FIPS</th><th>Type</th><th>Date range</th></tr>' + rows + '</table>'
+    : '<div class="empty">No scheduled tasks</div>';
+
+  var totalPages = Math.max(1, Math.ceil(data.total / data.per_page));
+  var page = data.page;
+  var pager = '<div class="pager">' +
+    '<button onclick="changePendingPage(-1)" ' + (page <= 0 ? 'disabled' : '') + '>&larr; Newer</button>' +
+    '<span>Page ' + (page + 1) + ' of ' + totalPages + '</span>' +
+    '<button onclick="changePendingPage(1)" ' + ((page + 1) >= totalPages ? 'disabled' : '') + '>Older &rarr;</button>' +
+    '</div>';
+
+  var dCount = lastStatus ? lastStatus.courts.district.pending_count : 0;
+  var cCount = lastStatus ? lastStatus.courts.circuit.pending_count : 0;
+  document.getElementById('pending-card').innerHTML =
+    '<h2>Scheduled tasks</h2>' +
+    '<div class="stats">' +
+      '<div class="stat"><div class="n">' + data.total + '</div><div class="l">Total pending</div></div>' +
+      '<div class="stat"><div class="n">' + dCount + '</div><div class="l">District</div></div>' +
+      '<div class="stat"><div class="n">' + cCount + '</div><div class="l">Circuit</div></div>' +
+    '</div>' + tbl + pager;
+}
+function loadPending() {
+  fetch('/api/pending?page=' + pendingPage)
+    .then(function(r){ return r.json(); })
+    .then(function(data){
+      var totalPages = Math.max(1, Math.ceil(data.total / data.per_page));
+      if (pendingPage > totalPages - 1) {
+        pendingPage = totalPages - 1;
+        return loadPending();
+      }
+      renderPending(data);
+    });
+}
+function changePendingPage(delta) {
+  pendingPage = Math.max(0, pendingPage + delta);
+  loadPending();
+}
 var ACTIVE_INTERVAL = 1000;
 var IDLE_INTERVAL = 10000;
 var refreshTimer = null;
@@ -704,6 +801,7 @@ function refresh() {
     document.getElementById('grid').innerHTML =
       courtCard('District', d.courts.district) + courtCard('Circuit', d.courts.circuit);
     loadCompleted();
+    loadPending();
     // Poll fast while any worker is active, slowly when everything is idle
     var anyActive = d.courts.district.active.length + d.courts.circuit.active.length > 0;
     var interval = anyActive ? ACTIVE_INTERVAL : IDLE_INTERVAL;

--- a/worker_dashboard.py
+++ b/worker_dashboard.py
@@ -647,7 +647,7 @@ function courtCard(name, c) {
       '<td><span class="dot ' + cls + '"></span>working</td>' +
       '<td>' + t.fips + '</td>' +
       '<td>' + t.case_type + '</td>' +
-      '<td>' + (t.start_date || '') + ' → ' + (t.end_date || '') + '</td>' +
+      '<td>' + (t.end_date || '') + ' → ' + (t.start_date || '') + '</td>' +
       '<td class="' + cls + '">' + fmtAgo(t.seconds_since) + '</td>' +
       '</tr>';
   }).join('');
@@ -690,7 +690,7 @@ function renderCompleted(data) {
       '<td>' + t.court + '</td>' +
       '<td>' + t.fips + '</td>' +
       '<td>' + t.case_type + '</td>' +
-      '<td>' + (t.start_date || '') + ' → ' + (t.end_date || '') + '</td>' +
+      '<td>' + (t.end_date || '') + ' → ' + (t.start_date || '') + '</td>' +
       '<td>' + fmtWhen(t.completed_at) + '</td>' +
       '</tr>';
   }).join('');
@@ -742,7 +742,7 @@ function renderPending(data) {
       '<td>' + t.court + '</td>' +
       '<td>' + t.fips + '</td>' +
       '<td>' + t.case_type + '</td>' +
-      '<td>' + (t.start_date || '') + ' → ' + (t.end_date || '') + '</td>' +
+      '<td>' + (t.end_date || '') + ' → ' + (t.start_date || '') + '</td>' +
       '</tr>';
   }).join('');
   var tbl = data.tasks.length

--- a/worker_dashboard.py
+++ b/worker_dashboard.py
@@ -19,6 +19,30 @@ PORT = 5000
 app = Flask(__name__)
 engine = create_engine("postgresql://" + os.environ['POSTGRES_DB'])
 
+
+def ensure_schema():
+    """Create the worker presence/target tables if they don't exist yet, so the
+    dashboard and supervisor work even before a collector has built the schema."""
+    ddl = [
+        'CREATE TABLE IF NOT EXISTS workers ('
+        ' worker_id VARCHAR PRIMARY KEY, court_type VARCHAR, status VARCHAR,'
+        ' fips INTEGER, case_type VARCHAR, last_alive TIMESTAMP)',
+        'CREATE TABLE IF NOT EXISTS worker_targets ('
+        ' court_type VARCHAR PRIMARY KEY, desired_count INTEGER, updated_at TIMESTAMP)',
+    ]
+    try:
+        with engine.begin() as conn:
+            for stmt in ddl:
+                conn.execute(text(stmt))
+    except Exception:
+        pass
+
+
+ensure_schema()
+
+# The court site becomes unstable past ~10 collectors, so cap the desired count.
+MAX_WORKERS = 10
+
 # Case tables are created by SQLAlchemy with mixed-case names. CASE_TABLE_NAMES
 # holds the raw name (for pg_class lookups); queries that hit the table directly
 # must double-quote it.
@@ -135,11 +159,30 @@ def collect_court_status(conn, court_type):
     except Exception:
         pass
 
+    # Desired count (set via the dashboard) vs. actual running collectors.
+    desired_count = 0
+    running_count = 0
+    try:
+        d = conn.execute(text(
+            'SELECT desired_count FROM worker_targets WHERE court_type = :ct'
+        ), {'ct': court_type}).scalar()
+        desired_count = int(d) if d is not None else 0
+    except Exception:
+        pass
+    try:
+        running_count = conn.execute(text(
+            'SELECT COUNT(*) FROM workers WHERE court_type = :ct'
+        ), {'ct': court_type}).scalar() or 0
+    except Exception:
+        pass
+
     has_active_workers = len(active) > 0
     return {
         'active': active,
         'idle': idle,
         'idle_count': len(idle),
+        'desired_count': desired_count,
+        'running_count': running_count,
         'completed': completed,
         'completed_count': scalar(conn, 'SELECT COUNT(*) FROM %s' % completed_table),
         'pending_count': scalar(conn, 'SELECT COUNT(*) FROM %s' % pending_table),
@@ -267,6 +310,30 @@ def create_tasks():
     return jsonify({'ok': True, 'created': len(fips_list)})
 
 
+@app.route('/api/workers/target', methods=['POST'])
+def set_worker_target():
+    data = request.get_json(force=True, silent=True) or {}
+    court_type = (data.get('court_type') or '').strip()
+    if court_type not in ('circuit', 'district'):
+        return jsonify({'ok': False, 'error': 'Invalid court level'}), 400
+    try:
+        desired = int(data.get('desired_count'))
+    except (TypeError, ValueError):
+        return jsonify({'ok': False, 'error': 'desired_count must be a number'}), 400
+    desired = max(0, min(MAX_WORKERS, desired))
+    try:
+        with engine.begin() as conn:
+            conn.execute(text(
+                'INSERT INTO worker_targets (court_type, desired_count, updated_at) '
+                'VALUES (:ct, :dc, :now) '
+                'ON CONFLICT (court_type) DO UPDATE SET '
+                'desired_count = EXCLUDED.desired_count, updated_at = EXCLUDED.updated_at'
+            ), {'ct': court_type, 'dc': desired, 'now': datetime.now()})
+    except Exception as e:
+        return jsonify({'ok': False, 'error': str(e)}), 500
+    return jsonify({'ok': True, 'court_type': court_type, 'desired_count': desired})
+
+
 @app.route('/')
 def index():
     return PAGE
@@ -293,6 +360,13 @@ PAGE = """<!DOCTYPE html>
   .scheduler button:hover { background: #2ea043; }
   .scheduler .msg { margin-left: 8px; font-size: 13px; color: #8a8f98; }
   .court h2 { font-size: 16px; margin: 0 0 12px; text-transform: capitalize; }
+  .court-head { display: flex; align-items: center; justify-content: space-between; }
+  .court-head h2 { margin: 0 0 12px; }
+  .worker-ctl { display: flex; align-items: center; gap: 6px; font-size: 13px; color: #8a8f98; }
+  .worker-ctl .run { color: #e6e6e6; }
+  .worker-ctl .lbl { font-size: 11px; text-transform: uppercase; letter-spacing: .04em; }
+  .worker-ctl button { background: #21262d; color: #e6e6e6; border: 1px solid #30363d; border-radius: 6px; width: 24px; height: 24px; cursor: pointer; font-size: 14px; line-height: 1; }
+  .worker-ctl button:hover { background: #30363d; }
   .court h3.section { font-size: 12px; color: #8a8f98; text-transform: uppercase; letter-spacing: .04em; margin: 18px 0 8px; }
   .stats { display: flex; gap: 16px; margin-bottom: 14px; flex-wrap: wrap; }
   .stat { background: #0f1115; border-radius: 6px; padding: 8px 12px; min-width: 90px; }
@@ -350,6 +424,14 @@ function fmtAgo(s) {
   if (s < 60) return s + 's ago';
   var m = Math.floor(s / 60);
   return m + 'm ' + (s % 60) + 's ago';
+}
+function setTarget(court, desired) {
+  if (desired < 0) desired = 0;
+  fetch('/api/workers/target', {
+    method: 'POST',
+    headers: {'Content-Type': 'application/json'},
+    body: JSON.stringify({court_type: court, desired_count: desired})
+  }).then(function(r){ return r.json(); }).then(function(d){ if (d.ok) refresh(); });
 }
 function createTasks() {
   var msg = document.getElementById('sch-msg');
@@ -411,8 +493,17 @@ function courtCard(name, c) {
     ? '<table><tr><th>Status</th><th>FIPS</th><th>Type</th><th>Date range</th><th>Last heartbeat</th></tr>' + allRows + '</table>'
     : '<div class="empty">No workers</div>';
 
+  var ct = name.toLowerCase();
+  var desired = c.desired_count || 0;
+  var workerCtl = '<div class="worker-ctl">' +
+    '<span class="run">' + (c.running_count || 0) + ' running</span> / ' +
+    '<button onclick="setTarget(&#39;' + ct + '&#39;,' + (desired - 1) + ')">&minus;</button>' +
+    '<b>' + desired + '</b>' +
+    '<button onclick="setTarget(&#39;' + ct + '&#39;,' + (desired + 1) + ')">+</button>' +
+    '<span class="lbl">desired</span></div>';
+
   return '<div class="court">' +
-    '<h2>' + name + '</h2>' +
+    '<div class="court-head"><h2>' + name + '</h2>' + workerCtl + '</div>' +
     '<div class="stats">' +
       '<div class="stat"><div class="n">' + c.pending_count + '</div><div class="l">Pending</div></div>' +
       '<div class="stat"><div class="n">' + c.completed_count + '</div><div class="l">Completed</div></div>' +
@@ -476,8 +567,15 @@ function changePage(delta) {
 }
 var ACTIVE_INTERVAL = 1000;
 var IDLE_INTERVAL = 10000;
-function scheduleNext(ms) { setTimeout(refresh, ms); }
+var refreshTimer = null;
+function scheduleNext(ms) {
+  if (refreshTimer) clearTimeout(refreshTimer);
+  refreshTimer = setTimeout(refresh, ms);
+}
 function refresh() {
+  // Cancel any pending tick so manual refreshes (e.g. from the worker control
+  // or task scheduler) restart the single loop instead of spawning extra ones.
+  if (refreshTimer) { clearTimeout(refreshTimer); refreshTimer = null; }
   fetch('/api/status').then(function(r){ return r.json(); }).then(function(d){
     lastStatus = d;
     document.getElementById('grid').innerHTML =

--- a/worker_supervisor.py
+++ b/worker_supervisor.py
@@ -1,0 +1,95 @@
+from __future__ import absolute_import
+from __future__ import print_function
+import os
+import sys
+import time
+import socket
+import subprocess
+from datetime import datetime
+
+from sqlalchemy import create_engine, text
+
+# Runs on each machine that should host collectors. Polls the worker_targets
+# table (set from the dashboard) and starts/stops local court_bulk_collector.py
+# processes so the number running matches the desired count. The dashboard never
+# spawns processes itself - it only writes the desired number here.
+
+COURT_TYPES = ['district', 'circuit']
+POLL_SECONDS = 5
+MAX_WORKERS = 10  # the court site becomes unstable past ~10 collectors
+
+engine = create_engine('postgresql://' + os.environ['POSTGRES_DB'])
+
+# Child collector processes we started, keyed by court type.
+children = {ct: [] for ct in COURT_TYPES}
+
+
+def ensure_target_table():
+    try:
+        with engine.begin() as conn:
+            conn.execute(text(
+                'CREATE TABLE IF NOT EXISTS worker_targets ('
+                ' court_type VARCHAR PRIMARY KEY, desired_count INTEGER, updated_at TIMESTAMP)'
+            ))
+    except Exception:
+        pass
+
+
+def get_desired(court_type):
+    try:
+        with engine.connect() as conn:
+            val = conn.execute(text(
+                'SELECT desired_count FROM worker_targets WHERE court_type = :ct'
+            ), {'ct': court_type}).scalar()
+        return max(0, min(MAX_WORKERS, int(val))) if val is not None else 0
+    except Exception:
+        return None  # DB unreachable - leave things as they are
+
+
+def reap(court_type):
+    children[court_type] = [p for p in children[court_type] if p.poll() is None]
+
+
+def start_worker(court_type):
+    kwargs = {}
+    if os.name == 'nt':
+        # Give each collector its own console window so its logs stay visible.
+        kwargs['creationflags'] = subprocess.CREATE_NEW_CONSOLE
+    p = subprocess.Popen([sys.executable, 'court_bulk_collector.py', court_type], **kwargs)
+    children[court_type].append(p)
+    print('[%s] started %s collector pid=%d' % (
+        datetime.now().strftime('%H:%M:%S'), court_type, p.pid))
+
+
+def stop_worker(court_type):
+    if children[court_type]:
+        p = children[court_type].pop()
+        try:
+            p.terminate()
+            print('[%s] stopped %s collector pid=%d' % (
+                datetime.now().strftime('%H:%M:%S'), court_type, p.pid))
+        except Exception:
+            pass
+
+
+def main():
+    ensure_target_table()
+    print('Supervisor running on %s (poll every %ds)' % (socket.gethostname(), POLL_SECONDS))
+    while True:
+        for court_type in COURT_TYPES:
+            reap(court_type)
+            desired = get_desired(court_type)
+            if desired is None:
+                continue
+            running = len(children[court_type])
+            while running < desired:
+                start_worker(court_type)
+                running += 1
+            while running > desired:
+                stop_worker(court_type)
+                running -= 1
+        time.sleep(POLL_SECONDS)
+
+
+if __name__ == '__main__':
+    main()

--- a/worker_supervisor.py
+++ b/worker_supervisor.py
@@ -4,6 +4,7 @@ import os
 import sys
 import time
 import socket
+import atexit
 import subprocess
 from datetime import datetime
 
@@ -13,16 +14,108 @@ from sqlalchemy import create_engine, text
 # table (set from the dashboard) and starts/stops local court_bulk_collector.py
 # processes so the number running matches the desired count. The dashboard never
 # spawns processes itself - it only writes the desired number here.
+#
+# Only one supervisor may run per host (enforced by a lock file). On startup it
+# kills any collectors already registered for this host, so it always begins from
+# a known state and cleans up orphans left by a previous run.
 
 COURT_TYPES = ['district', 'circuit']
 POLL_SECONDS = 5
 MAX_WORKERS = 10  # the court site becomes unstable past ~10 collectors
 LOG_DIR = 'worker_logs'  # each collector's output goes to its own file here
+LOCK_FILE = 'worker_supervisor.lock'
 
 engine = create_engine('postgresql://' + os.environ['POSTGRES_DB'])
 
 # Child collector processes we started, keyed by court type.
 children = {ct: [] for ct in COURT_TYPES}
+
+
+def pid_alive(pid):
+    if os.name == 'nt':
+        try:
+            out = subprocess.run(
+                ['tasklist', '/FI', 'PID eq %d' % pid],
+                capture_output=True, text=True)
+            return ('No tasks' not in out.stdout) and (str(pid) in out.stdout)
+        except Exception:
+            return False
+    try:
+        os.kill(pid, 0)
+        return True
+    except Exception:
+        return False
+
+
+def kill_pid(pid):
+    try:
+        if os.name == 'nt':
+            subprocess.call(['taskkill', '/F', '/PID', str(pid)],
+                            stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+        else:
+            os.kill(pid, 15)
+    except Exception:
+        pass
+
+
+def acquire_lock():
+    """Refuse to start if another live supervisor holds the lock on this host."""
+    if os.path.exists(LOCK_FILE):
+        try:
+            with open(LOCK_FILE) as f:
+                old_pid = int(f.read().strip())
+            if old_pid != os.getpid() and pid_alive(old_pid):
+                print('Another supervisor (pid=%d) is already running. Exiting.' % old_pid)
+                return False
+        except Exception:
+            pass  # stale/unreadable lock - take it over
+    try:
+        with open(LOCK_FILE, 'w') as f:
+            f.write(str(os.getpid()))
+        atexit.register(_release_lock)
+    except Exception:
+        pass
+    return True
+
+
+def _release_lock():
+    try:
+        if os.path.exists(LOCK_FILE):
+            os.remove(LOCK_FILE)
+    except Exception:
+        pass
+
+
+def registered_pids():
+    """Collector pids registered in the workers table for this host (worker_id is
+    'hostname-pid'), keyed by court type."""
+    host = socket.gethostname()
+    pids = {}
+    try:
+        with engine.connect() as conn:
+            rows = conn.execute(text(
+                'SELECT worker_id, court_type FROM workers WHERE worker_id LIKE :pfx'
+            ), {'pfx': host + '-%'}).fetchall()
+        for worker_id, court_type in rows:
+            try:
+                pids.setdefault(court_type, []).append(int(worker_id.rsplit('-', 1)[1]))
+            except Exception:
+                pass
+    except Exception:
+        pass
+    return pids
+
+
+def clean_slate():
+    """Kill any collectors already registered for this host so we start fresh."""
+    killed = 0
+    for court_type, pids in registered_pids().items():
+        for pid in pids:
+            if pid_alive(pid):
+                kill_pid(pid)
+                killed += 1
+    if killed:
+        print('Cleaned up %d pre-existing collector(s) on startup' % killed)
 
 
 def ensure_target_table():
@@ -94,7 +187,10 @@ def stop_worker(court_type):
 
 
 def main():
+    if not acquire_lock():
+        return
     ensure_target_table()
+    clean_slate()
     print('Supervisor running on %s (poll every %ds)' % (socket.gethostname(), POLL_SECONDS))
     while True:
         for court_type in COURT_TYPES:

--- a/worker_supervisor.py
+++ b/worker_supervisor.py
@@ -17,6 +17,7 @@ from sqlalchemy import create_engine, text
 COURT_TYPES = ['district', 'circuit']
 POLL_SECONDS = 5
 MAX_WORKERS = 10  # the court site becomes unstable past ~10 collectors
+LOG_DIR = 'worker_logs'  # each collector's output goes to its own file here
 
 engine = create_engine('postgresql://' + os.environ['POSTGRES_DB'])
 
@@ -47,18 +48,38 @@ def get_desired(court_type):
 
 
 def reap(court_type):
-    children[court_type] = [p for p in children[court_type] if p.poll() is None]
+    alive = []
+    for p in children[court_type]:
+        if p.poll() is None:
+            alive.append(p)
+        else:
+            logf = getattr(p, '_logf', None)
+            if logf is not None:
+                try:
+                    logf.close()
+                except Exception:
+                    pass
+    children[court_type] = alive
 
 
 def start_worker(court_type):
-    kwargs = {}
+    if not os.path.isdir(LOG_DIR):
+        try:
+            os.makedirs(LOG_DIR)
+        except Exception:
+            pass
+    log_path = os.path.join(
+        LOG_DIR, '%s-%s.log' % (court_type, datetime.now().strftime('%Y%m%d-%H%M%S-%f')))
+    logf = open(log_path, 'a')
+    # Run windowless and send output to the log file instead of a new console.
+    kwargs = {'stdout': logf, 'stderr': subprocess.STDOUT}
     if os.name == 'nt':
-        # Give each collector its own console window so its logs stay visible.
-        kwargs['creationflags'] = subprocess.CREATE_NEW_CONSOLE
+        kwargs['creationflags'] = subprocess.CREATE_NO_WINDOW
     p = subprocess.Popen([sys.executable, 'court_bulk_collector.py', court_type], **kwargs)
+    p._logf = logf  # keep the file handle alive until the process is reaped
     children[court_type].append(p)
-    print('[%s] started %s collector pid=%d' % (
-        datetime.now().strftime('%H:%M:%S'), court_type, p.pid))
+    print('[%s] started %s collector pid=%d -> %s' % (
+        datetime.now().strftime('%H:%M:%S'), court_type, p.pid, log_path))
 
 
 def stop_worker(court_type):


### PR DESCRIPTION
### Summary
Adds a live, browser-based dashboard for monitoring and controlling the scraper, plus the backend support it needs. Run it with `python worker_dashboard.py` (Flask is already in `requirements.txt`); it auto-opens the browser and is bound to `127.0.0.1`.

### Monitoring

- Live worker view per court type: active workers with heartbeat age (stale ones highlighted), pending/completed/dates-searched counts, and total cases collected.
- Idle workers stay visible — collectors register their presence in a new `workers` table via a process-level heartbeat, so a worker that finishes its last task shows as _idle_ instead of disappearing. State changes are written immediately.
- Hybrid case counts + adaptive refresh — while workers are active, case totals use PostgreSQL's instant row estimate (`~` prefix) and the page polls every 1s; when idle it shows exact cached counts and polls every 10s.
- Completed Tasks and Scheduled (pending) Tasks boxes, each paginated, shown side by side.
- Worker log viewer — a "Worker logs" window lists the per-worker log files and live-tails the selected one.

### Task scheduling

- A Task Scheduler form creates collection tasks from the UI (mirrors `court_bulk_task_creator.py`) via `POST /api/tasks/create`.

### Worker control (desired-count supervisor)

- Per-court worker control (`running / +- desired`) writes a target to a new `worker_targets` table; the dashboard never spawns processes itself.
- New `worker_supervisor.py` runs on each host, polls the target, and starts/stops local collectors to match (capped at 10). Collectors run windowless with output to per-worker files under `worker_logs/`.
- The supervisor is single-instance per host (lock file) and cleans up orphaned collectors on startup, preventing the double-spawn / un-stoppable-worker problem.

### Backend / reliability

- New tables: `workers`, `worker_targets`, and per-court `completed_date_tasks`; the dashboard ensures the presence/target tables exist at startup.
- Heartbeat optimizations: guard the `last_alive` migration so its `ALTER TABLE` only runs when the column is missing (avoids per-connection exclusive locks), and use one reused lightweight connection per heartbeat.
- Fix the watchdog skipping active tasks with a `NULL` heartbeat.

### Misc UI

- Date ranges display oldest → newest; "completed N ago" supports hours/days.

### New files
`worker_dashboard.py`, `worker_supervisor.py`